### PR TITLE
feat(addon): allow custom flow source

### DIFF
--- a/addon-AqaraPost/README.md
+++ b/addon-AqaraPost/README.md
@@ -40,6 +40,21 @@ Add custom component remote repository:
 
   * Restart addon
 
+## Test flows from another repository
+
+The add-on downloads flow JSON files from `flow_source_base_url`.
+Keep the default value for the latest upstream files, or set it to a fork,
+branch, tag, or commit raw URL before renewing the flow.
+The token generator script stays pinned to the upstream repository because it
+receives your Aqara account credentials.
+
+Example:
+
+```yaml
+flow_source_base_url: https://raw.githubusercontent.com/Komzpa/AqaraPOST-Homeassistant/my-branch
+renew_flow: true
+```
+
 ## Verify install
 
   * Check the value in the "config" node
@@ -70,5 +85,3 @@ Add custom component remote repository:
 	or change inject node:
 
 	![immagine](https://github.com/sdavides/AqaraPOST-Homeassistant/assets/31100253/ebf6ebad-bdb0-427e-add6-d8a3dcb8caa6)
-
-

--- a/addon-AqaraPost/config.yaml
+++ b/addon-AqaraPost/config.yaml
@@ -40,6 +40,7 @@ options:
   lumi1Aqara2: ""
   lumi1Aqara3: ""
   renew_flow: false
+  flow_source_base_url: https://raw.githubusercontent.com/sdavides/AqaraPOST-Homeassistant/main
   theme: default
   http_node:
     username: ""
@@ -62,6 +63,7 @@ schema:
   serverAqara: list(EU|CN|RU|KR|JP|AF|USA|OTHER|US|HMT|AU|ME)?
   timezoneAqara: list(it-IT|en-GB|en-US|fr-FR|de-DE|es-ES|pt-PT|sv-SE|nl-NL|pl-PL|da-DK|fi-FI|el-GR|cs-CZ|hu-HU|no-NO|sk-SK|es-MX|pt-BR|fr-CA|en-CA|es-US|es-CO|es-AR|es-CL|ja-JP|zh-CN|zh-TW|ko-KR|ar-SA|hi-IN|bn-IN|pa-IN|th-TH|vi-VN|he-IL|ar-EG|zu-ZA|af-ZA|sw-KE|so-SO|en-AU|en-NZ|mi-NZ|id-ID|ms-MY|ta-IN|te-IN|ur-PK|sr-RS|hr-HR|lt-LT|lv-LV)?
   renew_flow: bool?
+  flow_source_base_url: str?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   credential_secret: password?
   theme: list(default|aurora|cobalt2|dark|dracula|espresso-libre|github-dark|github-dark-default|github-dark-dimmed|midnight-red|monoindustrial|monokai|monokai-dimmed|night-owl|noctis|noctis-azureus|noctis-bordo|noctis-minimus|noctis-obscuro|noctis-sereno|noctis-uva|noctis-viola|oceanic-next|oled|one-dark-pro|one-dark-pro-darker|railscasts-extended|selenized-dark|selenized-light|solarized-dark|solarized-light|tokyo-night|tokyo-night-light|tokyo-night-storm|totallyinformation|zenburn|zendesk-garden)?

--- a/addon-AqaraPost/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run
+++ b/addon-AqaraPost/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run
@@ -42,14 +42,21 @@ else
 	bashio::log.info "Download json Aqara from GitHub"
 	touch /etc/node-red/flows.json || bashio::log.info "...."
 	bashio::log.info "......."
-	
-	FLOW_URL1="https://raw.githubusercontent.com/sdavides/AqaraPOST-Homeassistant/main/Aqara_G3_nodered.json"
+
+	FLOW_SOURCE_BASE_URL=$(bashio::config 'flow_source_base_url') || bashio::log.info "error flow_source_base_url ......."
+	if [ "$FLOW_SOURCE_BASE_URL" = "" ]; then
+	FLOW_SOURCE_BASE_URL="https://raw.githubusercontent.com/sdavides/AqaraPOST-Homeassistant/main"
+	fi
+	FLOW_SOURCE_BASE_URL="${FLOW_SOURCE_BASE_URL%/}"
+	bashio::log.info "Download AqaraPost flow files from $FLOW_SOURCE_BASE_URL"
+
+	FLOW_URL1="$FLOW_SOURCE_BASE_URL/Aqara_G3_nodered.json"
 	FLOW_NAME1="Aqara_G3_nodered"
 
-	FLOW_URL2="https://raw.githubusercontent.com/sdavides/AqaraPOST-Homeassistant/main/Aqara_FP2_nodered.json"
+	FLOW_URL2="$FLOW_SOURCE_BASE_URL/Aqara_FP2_nodered.json"
 	FLOW_NAME2="Aqara_FP2_nodered"
 
-	FLOW_URL3="https://raw.githubusercontent.com/sdavides/AqaraPOST-Homeassistant/main/Aqara_G3_nodered_2device.json"
+	FLOW_URL3="$FLOW_SOURCE_BASE_URL/Aqara_G3_nodered_2device.json"
 	FLOW_NAME3="Aqara_G3_nodered_2device"
 
 	LUMI1=$(bashio::config 'lumi1Aqara') || bashio::log.info "error lumi1Aqara ......."


### PR DESCRIPTION
## Summary

- Add an optional `flow_source_base_url` add-on setting for the downloaded Node-RED flow JSON files.
- Keep the default value pointed at `sdavides/AqaraPOST-Homeassistant/main`, so existing installs keep the same latest-upstream behavior.
- Strip a trailing slash before building flow URLs, making branch/tag/commit raw URLs easier to paste.
- Document how to test a fork or branch by setting `flow_source_base_url` and `renew_flow: true`.

## Why

The add-on already downloads the latest flow files at startup when renewing `flows.json`. This keeps that behavior, but makes it easier to test flow updates from a fork or PR branch before they are merged upstream.

The token generator remains pinned to the upstream repository because it receives the Aqara username and password; the configurable source is only used for flow JSON files.

## Validation

- `bash -n addon-AqaraPost/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run`
- Checked that G3, FP2, and G3_2 flow URLs are built from `flow_source_base_url`.
- Checked that `AqaraPOST-tokenGenerator.py` is still downloaded from the upstream repository, not from the configurable flow source.
- `git diff --check`
- `codex review --base origin/main`: no introduced defect found.
