### PR TITLE
fix(addon): preserve flows during renewal

### DIFF
--- a/addon-AqaraPost/README.md
+++ b/addon-AqaraPost/README.md
@@ -32,13 +32,18 @@ Add custom component remote repository:
 
 ## Update/Apply new config
 
-  * Delete "flows.json"
-    
-    * ( usually into "/addon_configs/XXX_nodered_aqara/" from SAMBA )
+  * Update the add-on config
 
-  * Update config
+  * Enable `renew_flow`
 
-  * Restart addon
+  * Restart the add-on
+
+  * Disable `renew_flow` after the restart finishes
+
+The add-on keeps the existing `/config/flows.json` when Home Assistant only
+provides masked `preconfigured` credentials or when token generation fails. Do
+not delete `flows.json` manually unless you have the Aqara username and password
+available and you are ready to recreate the flow from scratch.
 
 ## Test flows from another repository
 

--- a/addon-AqaraPost/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run
+++ b/addon-AqaraPost/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run
@@ -5,12 +5,13 @@
 # Configures Node-RED before running
 # ==============================================================================
 declare port
+declare renew_flow=false
+declare flow_workdir=""
 
 if bashio::config.true 'renew_flow'; then
 	bashio::log.info "renew_flow true"
-    rm /config/flows.json && 	bashio::log.info "/config/flows.json deleted"|| bashio::log.info "/config/flows.json not deleted"
-
-	else
+	renew_flow=true
+else
 	bashio::log.info "renew_flow false"
 fi
 
@@ -24,11 +25,26 @@ fi
 	bashio::log.info "Install cryptojs ..."
     cd /opt/node_modules && npm install cryptojs
 
-if  bashio::fs.file_exists '/config/flows.json'; then
+if bashio::fs.file_exists '/config/flows.json' && [ "$renew_flow" != "true" ]; then
 	bashio::log.info "......."
     bashio::log.info "flows.json already exist, the file will not be updated from config"
 	bashio::log.info "......."
 else
+	USERNAME=$(bashio::config 'usernameAqara') || USERNAME=
+	PASSWORD=$(bashio::config 'passwordAqara') || PASSWORD=
+
+	if [ "$USERNAME" = "" ] || [ "$USERNAME" = "preconfigured" ] || [ "$PASSWORD" = "" ] || [ "$PASSWORD" = "preconfigured" ] || [ "$PASSWORD" = "[]" ]; then
+		if bashio::fs.file_exists '/config/flows.json'; then
+			bashio::log.warning "renew_flow requested but Aqara credentials are missing or masked; keeping existing flows.json"
+			renew_flow=false
+		else
+			bashio::exit.nok "Cannot create AqaraPOST flows: usernameAqara/passwordAqara are missing or masked"
+		fi
+	fi
+
+fi
+
+if [ "$renew_flow" = "true" ] || ! bashio::fs.file_exists '/config/flows.json'; then
 	#Install python for token generator aqara
 	bashio::log.info "......."
 	bashio::log.info "Install python3/pycryptodome for token generator Aqara ..."
@@ -36,7 +52,9 @@ else
 	
 	#AqaraPost
 	bashio::log.info "......."
-	rm -rf /config/* && bashio::log.info "/config/flows.json not found, delete all folder and reset flow..." || bashio::log.info "......."
+	flow_workdir=$(mktemp -d) \
+		|| bashio::exit.nok "Failed to create temporary AqaraPost flow folder"
+	bashio::log.info "Prepare AqaraPost flow in temporary folder"
 	bashio::log.info "......."
 	
 	bashio::log.info "Download json Aqara from GitHub"
@@ -71,27 +89,27 @@ else
 	bashio::log.warning "G3 lumi1 not set"
 	else
 	LUMI1=$(echo "$LUMI1" | tr '[:upper:]' '[:lower:]' | sed -E 's/-//g; /^lumi1\./!s/^/lumi1./')
-	wget -q "$FLOW_URL1" --output-document=/etc/node-red/$FLOW_NAME1.json && bashio::log.info "Download AqaraPost $FLOW_NAME1.json complete..." || bashio::log.info "Error download AqaraPost $FLOW_NAME1 flow json"
+	wget -q "$FLOW_URL1" --output-document="$flow_workdir/$FLOW_NAME1.json" && bashio::log.info "Download AqaraPost $FLOW_NAME1.json complete..." || bashio::exit.nok "Error download AqaraPost $FLOW_NAME1 flow json"
 	fi
 	
     if [ "$LUMI2" = "" ]; then
 	bashio::log.warning "FP2 lumi1 not set"
 	else		
 	LUMI2=$(echo "$LUMI2" | tr '[:upper:]' '[:lower:]' | sed -E 's/-//g; /^lumi1\./!s/^/lumi1./')
-	wget -q "$FLOW_URL2" --output-document=/etc/node-red/$FLOW_NAME2.json && bashio::log.info "Download AqaraPost $FLOW_NAME2.json complete..." || bashio::log.info "Error download AqaraPost $FLOW_NAME2 flow json"
+	wget -q "$FLOW_URL2" --output-document="$flow_workdir/$FLOW_NAME2.json" && bashio::log.info "Download AqaraPost $FLOW_NAME2.json complete..." || bashio::exit.nok "Error download AqaraPost $FLOW_NAME2 flow json"
 	fi	
 	
 	if [ "$LUMI3" = "" ]; then	
 	bashio::log.warning "G3_2 lumi1 not set"
 	else
 	LUMI3=$(echo "$LUMI3" | tr '[:upper:]' '[:lower:]' | sed -E 's/-//g; /^lumi1\./!s/^/lumi1./')
-	wget -q "$FLOW_URL3" --output-document=/etc/node-red/$FLOW_NAME3.json && bashio::log.info "Download AqaraPost $FLOW_NAME3.json complete..." || bashio::log.info "Error download AqaraPost $FLOW_NAME3 flow json"
+	wget -q "$FLOW_URL3" --output-document="$flow_workdir/$FLOW_NAME3.json" && bashio::log.info "Download AqaraPost $FLOW_NAME3.json complete..." || bashio::exit.nok "Error download AqaraPost $FLOW_NAME3 flow json"
 	fi
 	
-	ls /etc/node-red/Aqara_*.json || bashio::log.info "...."
+	ls "$flow_workdir"/Aqara_*.json || bashio::exit.nok "No AqaraPost flow json was downloaded"
 		
 	bashio::log.info "Starting AqaraPost-Homeassistant tokenGenerator ..."
-	wget -q https://raw.githubusercontent.com/sdavides/AqaraPOST-Homeassistant/main/generatejson/AqaraPOST-tokenGenerator.py --output-document=/tmp/AqaraPOST-tokenGenerator.py  && chmod +x /tmp/AqaraPOST-tokenGenerator.py && ( echo $(bashio::config 'usernameAqara') ; echo $(bashio::config 'passwordAqara'); echo $(bashio::config 'serverAqara') )  | /tmp/AqaraPOST-tokenGenerator.py > /tmp/AqaraPOST-tokenGenerator.json || bashio::log.info "error......."
+	wget -q https://raw.githubusercontent.com/sdavides/AqaraPOST-Homeassistant/main/generatejson/AqaraPOST-tokenGenerator.py --output-document=/tmp/AqaraPOST-tokenGenerator.py  && chmod +x /tmp/AqaraPOST-tokenGenerator.py && ( echo "$USERNAME" ; echo "$PASSWORD"; echo $(bashio::config 'serverAqara') )  | /tmp/AqaraPOST-tokenGenerator.py > /tmp/AqaraPOST-tokenGenerator.json || bashio::exit.nok "error tokenGenerator"
 	cat /tmp/AqaraPOST-tokenGenerator.json | grep Username || bashio::log.info "Username Token error......."
 	cat /tmp/AqaraPOST-tokenGenerator.json | grep Area || bashio::log.info "Area Token error......."
 
@@ -130,22 +148,39 @@ else
     bashio::log.warning "error Server..."
 	SERVER=
     fi
+
+	if [ "$TOKEN" = "" ] || [ "$APPID" = "" ] || [ "$APPKEY" = "" ] || [ "$USERID" = "" ] || [ "$SERVER" = "" ]; then
+		if bashio::fs.file_exists '/config/flows.json'; then
+			bashio::log.warning "tokenGenerator did not return all required values; keeping existing flows.json"
+			rm -rf "$flow_workdir" || bashio::log.info "......."
+			rm -rf /tmp/AqaraPOST-tokenGenerator.py || bashio::log.info "......."
+			rm -rf /tmp/AqaraPOST-tokenGenerator.json || bashio::log.info "......."
+			renew_flow=false
+		else
+			bashio::exit.nok "Cannot create AqaraPOST flows: tokenGenerator did not return all required values"
+		fi
+	fi
+
+	if [ "$renew_flow" = "true" ] || ! bashio::fs.file_exists '/config/flows.json'; then
 	
-	if  bashio::fs.file_exists '/etc/node-red/'$FLOW_NAME1'.json'; then
-	sed -i "s/XXXXXXAREAXXXXXXXXXXX/$AREA/g" /etc/node-red/$FLOW_NAME1.json && sed -i "s/XXXXXXTOKENXXXXXXXXXXX/$TOKEN/g" /etc/node-red/$FLOW_NAME1.json && sed -i "s/XXXXXXAPPIDXXXXXXXXXXX/$APPID/g" /etc/node-red/$FLOW_NAME1.json && sed -i "s/XXXXXXAPPKEYXXXXXXXXXXX/$APPKEY/g" /etc/node-red/$FLOW_NAME1.json && sed -i "s/XXXXXXUSERIDXXXXXXXXXXX/$USERID/g" /etc/node-red/$FLOW_NAME1.json && sed -i "s/lumi1.XXXXXXXXXXXX/$LUMI1/g" /etc/node-red/$FLOW_NAME1.json && sed -i "s/rpc-ger.aqara.com/$SERVER/g" /etc/node-red/$FLOW_NAME1.json && sed -i "s/it-IT/$TIMEZONE/g" /etc/node-red/$FLOW_NAME1.json && bashio::log.info "tokenGenerator Insert value $FLOW_NAME1.json complete." || bashio::log.info "Error AqaraPost-Homeassistant tokenGenerator ..."
+	if  bashio::fs.file_exists "$flow_workdir/$FLOW_NAME1.json"; then
+	sed -i "s/XXXXXXAREAXXXXXXXXXXX/$AREA/g" "$flow_workdir/$FLOW_NAME1.json" && sed -i "s/XXXXXXTOKENXXXXXXXXXXX/$TOKEN/g" "$flow_workdir/$FLOW_NAME1.json" && sed -i "s/XXXXXXAPPIDXXXXXXXXXXX/$APPID/g" "$flow_workdir/$FLOW_NAME1.json" && sed -i "s/XXXXXXAPPKEYXXXXXXXXXXX/$APPKEY/g" "$flow_workdir/$FLOW_NAME1.json" && sed -i "s/XXXXXXUSERIDXXXXXXXXXXX/$USERID/g" "$flow_workdir/$FLOW_NAME1.json" && sed -i "s/lumi1.XXXXXXXXXXXX/$LUMI1/g" "$flow_workdir/$FLOW_NAME1.json" && sed -i "s/rpc-ger.aqara.com/$SERVER/g" "$flow_workdir/$FLOW_NAME1.json" && sed -i "s/it-IT/$TIMEZONE/g" "$flow_workdir/$FLOW_NAME1.json" && bashio::log.info "tokenGenerator Insert value $FLOW_NAME1.json complete." || bashio::exit.nok "Error AqaraPost-Homeassistant tokenGenerator"
 	fi
 		
-	if  bashio::fs.file_exists '/etc/node-red/'$FLOW_NAME2'.json'; then
-	sed -i "s/XXXXXXAREAXXXXXXXXXXX/$AREA/g" /etc/node-red/$FLOW_NAME2.json && sed -i "s/XXXXXXTOKENXXXXXXXXXXX/$TOKEN/g" /etc/node-red/$FLOW_NAME2.json && sed -i "s/XXXXXXAPPIDXXXXXXXXXXX/$APPID/g" /etc/node-red/$FLOW_NAME2.json  && sed -i "s/XXXXXXAPPKEYXXXXXXXXXXX/$APPKEY/g" /etc/node-red/$FLOW_NAME2.json && sed -i "s/XXXXXXUSERIDXXXXXXXXXXX/$USERID/g" /etc/node-red/$FLOW_NAME2.json && sed -i "s/lumi1.XXXXXXXXXXXX/$LUMI2/g" /etc/node-red/$FLOW_NAME2.json && sed -i "s/rpc-ger.aqara.com/$SERVER/g" /etc/node-red/$FLOW_NAME2.json && sed -i "s/it-IT/$TIMEZONE/g" /etc/node-red/$FLOW_NAME2.json && bashio::log.info "tokenGenerator Insert value $FLOW_NAME2.json complete." || bashio::log.info "Error AqaraPost-Homeassistant tokenGenerator ..."
+	if  bashio::fs.file_exists "$flow_workdir/$FLOW_NAME2.json"; then
+	sed -i "s/XXXXXXAREAXXXXXXXXXXX/$AREA/g" "$flow_workdir/$FLOW_NAME2.json" && sed -i "s/XXXXXXTOKENXXXXXXXXXXX/$TOKEN/g" "$flow_workdir/$FLOW_NAME2.json" && sed -i "s/XXXXXXAPPIDXXXXXXXXXXX/$APPID/g" "$flow_workdir/$FLOW_NAME2.json"  && sed -i "s/XXXXXXAPPKEYXXXXXXXXXXX/$APPKEY/g" "$flow_workdir/$FLOW_NAME2.json" && sed -i "s/XXXXXXUSERIDXXXXXXXXXXX/$USERID/g" "$flow_workdir/$FLOW_NAME2.json" && sed -i "s/lumi1.XXXXXXXXXXXX/$LUMI2/g" "$flow_workdir/$FLOW_NAME2.json" && sed -i "s/rpc-ger.aqara.com/$SERVER/g" "$flow_workdir/$FLOW_NAME2.json" && sed -i "s/it-IT/$TIMEZONE/g" "$flow_workdir/$FLOW_NAME2.json" && bashio::log.info "tokenGenerator Insert value $FLOW_NAME2.json complete." || bashio::exit.nok "Error AqaraPost-Homeassistant tokenGenerator"
 	fi
 	
-	if  bashio::fs.file_exists '/etc/node-red/'$FLOW_NAME3'.json'; then
-	sed -i "s/XXXXXXAREAXXXXXXXXXXX/$AREA/g" /etc/node-red/$FLOW_NAME3.json && sed -i "s/XXXXXXTOKENXXXXXXXXXXX/$TOKEN/g" /etc/node-red/$FLOW_NAME3.json && sed -i "s/XXXXXXAPPIDXXXXXXXXXXX/$APPID/g" /etc/node-red/$FLOW_NAME3.json  && sed -i "s/XXXXXXAPPKEYXXXXXXXXXXX/$APPKEY/g" /etc/node-red/$FLOW_NAME3.json && sed -i "s/XXXXXXUSERIDXXXXXXXXXXX/$USERID/g" /etc/node-red/$FLOW_NAME3.json && sed -i "s/lumi1.XXXXXXXXXXXX/$LUMI3/g" /etc/node-red/$FLOW_NAME3.json && sed -i "s/rpc-ger.aqara.com/$SERVER/g" /etc/node-red/$FLOW_NAME3.json && sed -i "s/it-IT/$TIMEZONE/g" /etc/node-red/$FLOW_NAME3.json && bashio::log.info "tokenGenerator Insert value $FLOW_NAME3.json complete." || bashio::log.info "Error AqaraPost-Homeassistant tokenGenerator ..."
+	if  bashio::fs.file_exists "$flow_workdir/$FLOW_NAME3.json"; then
+	sed -i "s/XXXXXXAREAXXXXXXXXXXX/$AREA/g" "$flow_workdir/$FLOW_NAME3.json" && sed -i "s/XXXXXXTOKENXXXXXXXXXXX/$TOKEN/g" "$flow_workdir/$FLOW_NAME3.json" && sed -i "s/XXXXXXAPPIDXXXXXXXXXXX/$APPID/g" "$flow_workdir/$FLOW_NAME3.json"  && sed -i "s/XXXXXXAPPKEYXXXXXXXXXXX/$APPKEY/g" "$flow_workdir/$FLOW_NAME3.json" && sed -i "s/XXXXXXUSERIDXXXXXXXXXXX/$USERID/g" "$flow_workdir/$FLOW_NAME3.json" && sed -i "s/lumi1.XXXXXXXXXXXX/$LUMI3/g" "$flow_workdir/$FLOW_NAME3.json" && sed -i "s/rpc-ger.aqara.com/$SERVER/g" "$flow_workdir/$FLOW_NAME3.json" && sed -i "s/it-IT/$TIMEZONE/g" "$flow_workdir/$FLOW_NAME3.json" && bashio::log.info "tokenGenerator Insert value $FLOW_NAME3.json complete." || bashio::exit.nok "Error AqaraPost-Homeassistant tokenGenerator"
 	fi
 		
-	jq -s 'add' /etc/node-red/Aqara_*json > /etc/node-red/flows.json && rm -rf /etc/node-red/Aqara_*json && bashio::log.info "flows.json created" || bashio::log.info "......." 
+	jq -s 'add' "$flow_workdir"/Aqara_*json > /tmp/AqaraPOST-flows.json && mv /tmp/AqaraPOST-flows.json /config/flows.json && bashio::log.info "flows.json created" || bashio::exit.nok "Error creating flows.json"
+	rm -rf "$flow_workdir" || bashio::log.info "......."
 	rm -rf /tmp/AqaraPOST-tokenGenerator.py || bashio::log.info "......."
 	rm -rf /tmp/AqaraPOST-tokenGenerator.json || bashio::log.info "......."
+
+	fi
 	
 	bashio::log.info "......."
 	bashio::log.info "End AqaraPost-Homeassistant flow" 
@@ -171,7 +206,9 @@ if ! bashio::fs.file_exists '/config/settings.js'; then
 
     # Copy in template files & Create random flow id
     id=$(node -e "console.log((2+Math.random()*4294967295).toString(26));")
-    cp /etc/node-red/flows.json /config/ && sed -i "s/%%ID%%/${id}/" "/config/flows.json" || bashio::log.info "Failed cp /etc/node-red/flows.json /config/ template"
+    if ! bashio::fs.file_exists '/config/flows.json'; then
+        cp /etc/node-red/flows.json /config/ && sed -i "s/%%ID%%/${id}/" "/config/flows.json" || bashio::log.info "Failed cp /etc/node-red/flows.json /config/ template"
+    fi
     cp /etc/node-red/settings.js /config/ || bashio::log.info "Failed cp /etc/node-red/settings.js /config/ template"
 fi
 


### PR DESCRIPTION
## Summary

- stop deleting `/config/flows.json` before Aqara credentials and token generation are known to be usable
- build renewed flows in a temporary directory and only replace `/config/flows.json` after the new flow is fully generated
- keep the existing flow when Home Assistant returns masked `preconfigured` credentials or token generation misses required fields
- update the renewal docs so users no longer have to manually delete `flows.json`

## Why

On an existing add-on install, Home Assistant can expose saved password options to the add-on as masked values such as `preconfigured`. With the previous `renew_flow` flow, the add-on deleted the working `flows.json` first, then tried to regenerate with masked credentials. If token generation failed, the working Node-RED flow was already gone.

This also removes the reset-style `rm -rf /config/*` path and keeps Node-RED configuration intact during flow renewal.

## Validation

- `bash -n addon-AqaraPost/rootfs/etc/s6-overlay/s6-rc.d/init-nodered/run`
- `python3 -m json.tool Aqara_FP2_nodered.json`
- `python3 -m json.tool Aqara_G3_nodered.json`
- `python3 -m json.tool Aqara_G3_nodered_2device.json`
- `git diff --check`
- `codex review --base origin/main`
